### PR TITLE
feat(fonticon): support fonticons now provided by patternfly

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -32,8 +32,8 @@ module.exports = {
         },
         include: function (input) {
           // only process modules with this loader
-          // if they live under a 'fonts' directory
-          return input.indexOf('fonts') > -1;
+          // if they live under a 'fonts' or 'pficon' directory
+          return (input.indexOf('fonts') > -1 || input.indexOf('pficon') > -1);
         }
       },
       {


### PR DESCRIPTION
This PR allows file-loader to process fonticons now provided by patternfly. Previously, this loader was only processing modules under the fonts directory, now they exist also under pficon directory, so we test for that also.