### PR TITLE
fix(sourcemaps): ensure sourcemaps point back to precompiled source

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -6,7 +6,7 @@ const PORT = process.env.PORT || "9000";
 
 module.exports = merge(common, {
   mode: "development",
-  devtool: "inline-source-map",
+  devtool: "eval-source-map",
   devServer: {
     contentBase: "./dist",
     host: HOST,


### PR DESCRIPTION
This PR makes the source maps better by having them point to the original source files during dev.