### PR TITLE
chore(config): adjust ts configuration to better align with pf examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/node": "^11.9.6",
     "@types/react": "^16.8.6",
     "@types/react-dom": "^16.8.2",
+    "@types/victory": "^31.0.14",
     "@types/webpack": "^4.4.25",
     "css-loader": "^1.0.1",
     "enzyme": "^3.7.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noImplicitAny": true,
+    "noImplicitAny": false,
     "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -393,6 +393,13 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/victory@^31.0.14":
+  version "31.0.14"
+  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.14.tgz#253696ec00609e733f004fe1e2609735deeb9d46"
+  integrity sha512-/xeAjRJFMgu7G8ZAJeZW+mdN0gBWocxOq/KT6vUnu0Q5cyYJ80O4Vo0Jrn7G5QZ+dXyyYa8/CvjP34RcBmZFww==
+  dependencies:
+    "@types/react" "*"
+
 "@types/webpack@^4.4.25":
   version "4.4.25"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.25.tgz#c8a1eb968a33a3e6da641f529c5add0d44d34809"


### PR DESCRIPTION
This PR fixes an issue where users getting started with pf seed would encounter errors upon following the hello world examples for some of the [chart](https://github.com/patternfly/patternfly-react/issues/1603) components.

Not sure what's missing, but the following screenshot shows what we get when the example is rendered, notice the missing domain/range labels.

<img width="1191" alt="Screen Shot 2019-03-24 at 10 07 42 AM" src="https://user-images.githubusercontent.com/5942899/54880917-d28eba80-4e20-11e9-9eb2-19d1c8457ea9.png">

<img width="463" alt="Screen Shot 2019-03-24 at 10 37 12 AM" src="https://user-images.githubusercontent.com/5942899/54880918-d28eba80-4e20-11e9-8914-eecdc460d1a9.png">

In any case, this should help speed up the getting started experience for people.