### PR TITLE
feat(module-support): add more support for various file types

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,4 +1,12 @@
 declare module '*.png';
 declare module '*.jpg';
+declare module '*.jpeg';
 declare module '*.gif';
 declare module '*.svg';
+declare module '*.css';
+declare module '*.wav';
+declare module '*.mp3';
+declare module '*.m4a';
+declare module '*.rdf';
+declare module '*.ttl';
+declare module '*.pdf';


### PR DESCRIPTION
This PR declares module support for various common file types. In some setups these don't seem to be necessary, however, some users have reported needing to explicitly declare here in typings even just to import a CSS module for example. One less stumbling block.