### PR TITLE
chore(documentation): illustrate various ways of importing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,31 @@ Launch a tool to inspect the bundle size
 * [TypeScript Config](./tsconfig.json)
 * [Webpack Config](./webpack.common.js)
 * [Jest Config](./jest.config.js)
+* [Editor Config](./.editorconfig)
+
+## Image Support
+
+To use an image asset that's shipped with patternfly core, you'll prefix the paths with `@pfassets`. `@pfassets` is an alias for the patternfly assets directory in node_modules.
+
+`import imgSrc from '@pfassets/images/g_sizing.png';`
+Then you can use it like:
+`<img src={imgSrc} alt="Some image" />`
+
+You can use a similar technique to import assets from your local app, just prefix the paths with. `@app`.
+`import loader from '@app/assets/images/loader.gif';`
+`<img src={loader} alt="Content loading />`
+
+Inlining SVG in the app's markup is also possible.
+`import logo from '@app/assets/images/logo.svg';`
+Then you can use it like:
+`<span dangerouslySetInnerHTML={{__html: logo}} />`
+
+You can also use SVG to apply background images with CSS. To do this, your svg's must live under a `bgimages` directory. This is necessary because you may need to use SVG's in several other context (inline images, fonts, icons, etc.) and so we need to be able to differentiate between these usages so the appropriate loader is invoked.
+```css
+body {
+  background: url(./assets/bgimages/img_avatar.svg);
+}
+```
 
 ## Code Quality Tools
 * For accessibility compliance, we use [react-axe](https://github.com/dequelabs/react-axe)


### PR DESCRIPTION
This PR shows users how to incorporate various types of images into the app with code snippets to help get them started. This should speed up the getting started process.

<img width="828" alt="Screen Shot 2019-03-28 at 1 38 36 PM" src="https://user-images.githubusercontent.com/5942899/55179896-d4c58180-515e-11e9-8ecc-c51bbc218799.png">
