### PR TITLE
chore(paths): register path alias with jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+    "@app/(.*)": '<rootDir>/src/app/$1'
   },
 
   // A preset that is used as a base for Jest's configuration

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import App from '.';
+import App from '@app/index';
 import { mount, shallow } from 'enzyme';
 import { Alert, Button } from '@patternfly/react-core';
 


### PR DESCRIPTION
This PR adds a new entry for the jest `moduleNameMapper` config. The problem was that when jest encountered a module which used a path alias `@app/*` it failed the lookup, as seen in the screenshot below.

<img width="595" alt="Screen Shot 2019-03-29 at 8 44 24 AM" src="https://user-images.githubusercontent.com/5942899/55233593-73a1ba80-51ff-11e9-9d5a-3704d758e6bb.png">

The test suite should also be able to resolve these types of references just like for the app runtime. With this PR in place, users can now do this as seen below.

<img width="550" alt="Screen Shot 2019-03-29 at 8 44 56 AM" src="https://user-images.githubusercontent.com/5942899/55233642-9338e300-51ff-11e9-914a-e0bbb3fa47ad.png">