### PR TITLE
chore(webpack): tune webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@patternfly/react-icons": "^3.10.10",
     "@patternfly/react-styles": "^3.4.6",
     "react-document-title": "^2.0.3",
-    "react-router-dom": "^5.0.1"
+    "react-router-dom": "^5.0.1",
+    "react-router-last-location": "^2.0.1"
   }
 }

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -53,7 +53,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
         {routes.map((route, idx) => {
           return (
             <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`}>
-              <NavLink to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
+              <NavLink exact={true} to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
             </NavItem>
           );
         })}

--- a/src/app/DynamicImport.tsx
+++ b/src/app/DynamicImport.tsx
@@ -11,6 +11,14 @@ class DynamicImport extends React.Component<IDynamicImport> {
   public state = {
     component: null
   };
+  private routeFocusTimer: number;
+  constructor(props: IDynamicImport) {
+    super(props);
+    this.routeFocusTimer = 0;
+  }
+  public componentWillUnmount() {
+    window.clearTimeout(this.routeFocusTimer);
+  }
   public componentDidMount() {
     this.props.load().then(component => {
       if (component) {
@@ -21,7 +29,7 @@ class DynamicImport extends React.Component<IDynamicImport> {
     })
       .then(() => {
         if (this.props.focusContentAfterMount) {
-          accessibleRouteChangeHandler();
+          this.routeFocusTimer = accessibleRouteChangeHandler();
         }
       });
   }

--- a/src/app/DynamicImport.tsx
+++ b/src/app/DynamicImport.tsx
@@ -4,6 +4,7 @@ import { accessibleRouteChangeHandler } from '@app/utils/utils';
 interface IDynamicImport {
   load: () => Promise<any>;
   children: any;
+  focusContentAfterMount: boolean;
 }
 
 class DynamicImport extends React.Component<IDynamicImport> {
@@ -18,9 +19,11 @@ class DynamicImport extends React.Component<IDynamicImport> {
         });
       }
     })
-    .then(() => {
-      accessibleRouteChangeHandler();
-    });
+      .then(() => {
+        if (this.props.focusContentAfterMount) {
+          accessibleRouteChangeHandler();
+        }
+      });
   }
   public render() {
     return this.props.children(this.state.component);

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -6,7 +6,7 @@ const NotFound: React.FunctionComponent = () => {
   return (
     <PageSection>
       <Alert variant="danger" title="404! This view hasn't been created yet." /><br />
-      <NavLink to="/dashboard" className="pf-c-nav__link">Back to Dashboard</NavLink>
+      <NavLink to="/" className="pf-c-nav__link">Take me home</NavLink>
     </PageSection>
   );
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { Alert, PageSection } from '@patternfly/react-core';
 import { DynamicImport } from '@app/DynamicImport';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
@@ -7,7 +7,7 @@ import { Dashboard } from '@app/Dashboard/Dashboard';
 import { NotFound } from '@app/NotFound/NotFound';
 import DocumentTitle from 'react-document-title';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
-
+let routeFocusTimer: number;
 const getSupportModuleAsync = () => {
   return () => import(/* webpackChunkName: 'support' */ '@app/Support/Support');
 };
@@ -42,6 +42,7 @@ const RouteWithTitleUpdates = ({
   ...rest
 }) => {
   const lastNavigation = useLastLocation();
+
   function routeWithTitle(routeProps: RouteComponentProps) {
     return (
       <DocumentTitle title={title}>
@@ -52,8 +53,11 @@ const RouteWithTitleUpdates = ({
 
   React.useEffect(() => {
     if (!isAsync && lastNavigation !== null) {
-      accessibleRouteChangeHandler()
+      routeFocusTimer = accessibleRouteChangeHandler()
     }
+    return () => {
+      clearTimeout(routeFocusTimer);
+    };
   }, []);
 
   return (

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -1,5 +1,5 @@
 export function accessibleRouteChangeHandler() {
-  setTimeout(() => {
+  return window.setTimeout(() => {
     const mainContainer = document.getElementById('primary-app-container');
     if (mainContainer) {
       mainContainer.focus();

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -1,6 +1,8 @@
 export function accessibleRouteChangeHandler() {
-  const mainContainer = document.getElementById('primary-app-container');
-  if (mainContainer) {
-    mainContainer.focus();
-  }
+  setTimeout(() => {
+    const mainContainer = document.getElementById('primary-app-container');
+    if (mainContainer) {
+      mainContainer.focus();
+    }
+  }, 50);
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -36,6 +36,8 @@ module.exports = {
           path.resolve(__dirname, 'node_modules/patternfly/dist/fonts'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/fonts'),
           path.resolve(__dirname, 'node_modules/@patternfly/react-core/dist/styles/assets/pficon'),
+          path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/fonts'),
+          path.resolve(__dirname, 'node_modules/@patternfly/patternfly/assets/pficon')
         ],
         use: {
           loader: 'file-loader',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7183,6 +7183,11 @@ react-router-dom@^5.0.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-last-location@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-router-last-location/-/react-router-last-location-2.0.1.tgz#54d625876dd1448594fa1114aa02e7e21db12970"
+  integrity sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ==
+
 react-router@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.1.tgz#04ee77df1d1ab6cb8939f9f01ad5702dbadb8b0f"


### PR DESCRIPTION
This PR adds a small pkg to track the last route so that we can fine-tune the AX by not sending focus upon initially loading the app. It also registers a couple of new directories in the webpack config that users are likely to need at some point. Finally, I switched the default "home" route to be "/" instead of "/dashboard". 

only focus on new content when a user navigates in-app
add a small delay before sending focus for JAWS