### PR TITLE
chore(paths): ensure asset paths are relative to the root of app

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta id="appName" name="application-name" content="Patternfly Seed">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/png" href="https://www.patternfly.org/components/patternfly/dist/img/favicon.ico">
+  <base href="/">
 </head>
 
 <body>


### PR DESCRIPTION
This PR adds a `base` element to the head section of the main index file. This ensures assets are loaded relative to the web app root, and not somewhere else.

Loading SPAs in subdirectories may require more advanced configuration with some sort of client/server handshake and is beyond scope of what seed aims to solve out of the box. These changes assume users are loading the UI at the root of the webserver.

Should help close https://github.com/patternfly/patternfly-react-seed/issues/68
