### PR TITLE
Add 'npm run type-check' and 'npm run ci-checks' scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "eslint": "eslint --ext .tsx,.js ./src/",
     "lint": "npm run eslint",
     "format": "prettier --check --write ./src/**/*.{tsx,ts}",
+    "type-check": "tsc --noEmit",
+    "ci": "npm run type-check && npm run lint && npm run test",
     "build:bundle-profile": "webpack --config webpack.prod.js --profile --json > stats.json",
     "bundle-profile:analyze": "npm run build:bundle-profile && webpack-bundle-analyzer ./stats.json",
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "npm run eslint",
     "format": "prettier --check --write ./src/**/*.{tsx,ts}",
     "type-check": "tsc --noEmit",
-    "ci": "npm run type-check && npm run lint && npm run test",
+    "ci-checks": "npm run type-check && npm run lint && npm run test",
     "build:bundle-profile": "webpack --config webpack.prod.js --profile --json > stats.json",
     "bundle-profile:analyze": "npm run build:bundle-profile && webpack-bundle-analyzer ./stats.json",
     "clean": "rimraf dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
       "@app/*": ["src/app/*"],
       "@assets/*": ["node_modules/@patternfly/react-core/dist/styles/assets/*"]
     },
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
Currently, a TypeScript error will not prevent the bundle from compiling, and there is no script for running `tsc` to type-check your app on the command line or in CI.

This PR provides two new package.json scripts, `type-check` and `ci-checks`. The former runs `tsc --noEmit`, which will fail if there are any TS errors in the source. The latter runs the `type-check`, `lint` and `test` scripts, and makes it easy for a consumer to hook that up to CI to make sure their pull requests are not breaking type-safety or their linter in addition to their unit tests.

It might also be a good idea to put an example Travis CI or Circle CI config in here which runs `npm run ci-checks`.

Note: I did have to add the `skipLibCheck` option to tsconfig.json so the `type-check` script wouldn't check .d.ts files in node_modules.