### PR TITLE
Install @types/react-router-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6540,6 +6540,27 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-router": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.8.tgz",
+      "integrity": "sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.5.tgz",
+      "integrity": "sha512-ArBM4B1g3BWLGbaGvwBGO75GNFbLDUthrDojV2vHLih/Tq8M+tgvY1DSwkuNrPSwdp/GUL93WSEpTZs8nVyJLw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^25.2.3",
+    "@types/react-router-dom": "^5.1.5",
     "@types/victory": "^33.1.4",
     "@typescript-eslint/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^3.1.0",


### PR DESCRIPTION
Fixes this TypeScript warning/recommendation seen in `src/app/routes.tsx`:
<img width="1061" alt="Screenshot 2020-07-21 17 21 20" src="https://user-images.githubusercontent.com/811963/88108360-b3b84980-cb76-11ea-8720-a5f4d2633585.png">

The props passed to `<Route>` and `<Switch>` were not being checked because those type interfaces are not included in the react-router-dom library.