### PR TITLE
Add support for expandable nav groups in route definition

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,15 +1,16 @@
 import * as React from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import {
   Nav,
   NavList,
   NavItem,
+  NavExpandable,
   Page,
   PageHeader,
   PageSidebar,
   SkipToContent
 } from '@patternfly/react-core';
-import { routes } from '@app/routes';
+import { routes, IAppRoute, IAppRouteGroup } from '@app/routes';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -42,14 +43,33 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({children}) => {
     />
   );
 
+  const location = useLocation();
+
+  const renderNavItem = (route: IAppRoute, index: number) => (
+    <NavItem key={`${route.label}-${index}`} id={`${route.label}-${index}`}>
+      <NavLink exact to={route.path} activeClassName="pf-m-current">
+        {route.label}
+      </NavLink>
+    </NavItem>
+  );
+
+  const renderNavGroup = (group: IAppRouteGroup, groupIndex: number) => (
+    <NavExpandable
+      key={`${group.label}-${groupIndex}`}
+      id={`${group.label}-${groupIndex}`}
+      title={group.label}
+      isActive={group.routes.some((route) => route.path === location.pathname)}
+    >
+      {group.routes.map((route, idx) => route.label && renderNavItem(route, idx))}
+    </NavExpandable>
+  );
+
   const Navigation = (
     <Nav id="nav-primary-simple" theme="dark">
       <NavList id="nav-list-simple">
-        {routes.map((route, idx) => route.label && (
-            <NavItem key={`${route.label}-${idx}`} id={`${route.label}-${idx}`}>
-              <NavLink exact to={route.path} activeClassName="pf-m-current">{route.label}</NavLink>
-            </NavItem>
-          ))}
+        {routes.map(
+          (route, idx) => route.label && (!route.routes ? renderNavItem(route, idx) : renderNavGroup(route, idx))
+        )}
       </NavList>
     </Nav>
   );

--- a/src/app/Settings/General/GeneralSettings.tsx
+++ b/src/app/Settings/General/GeneralSettings.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { PageSection, Title } from '@patternfly/react-core';
+
+const GeneralSettings: React.FunctionComponent = () => (
+  <PageSection>
+    <Title headingLevel="h1" size="lg">
+      General Settings Page Title
+    </Title>
+  </PageSection>
+);
+
+export { GeneralSettings };

--- a/src/app/Settings/Profile/ProfileSettings.tsx
+++ b/src/app/Settings/Profile/ProfileSettings.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { PageSection, Title } from '@patternfly/react-core';
+
+const ProfileSettings: React.FunctionComponent = () => (
+  <PageSection>
+    <Title headingLevel="h1" size="lg">
+      Profile Settings Page Title
+    </Title>
+  </PageSection>
+);
+
+export { ProfileSettings };

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -4,6 +4,8 @@ import { Alert, PageSection } from '@patternfly/react-core';
 import { DynamicImport } from '@app/DynamicImport';
 import { accessibleRouteChangeHandler } from '@app/utils/utils';
 import { Dashboard } from '@app/Dashboard/Dashboard';
+import { GeneralSettings } from '@app/Settings/General/GeneralSettings';
+import { ProfileSettings } from '@app/Settings/Profile/ProfileSettings';
 import { NotFound } from '@app/NotFound/NotFound';
 import { useDocumentTitle } from '@app/utils/useDocumentTitle';
 import { LastLocationProvider, useLastLocation } from 'react-router-last-location';
@@ -38,7 +40,7 @@ const Support = (routeProps: RouteComponentProps): React.ReactElement => {
 };
 
 export interface IAppRoute {
-  label?: string;
+  label?: string; // Excluding the label will exclude the route from the nav sidebar in AppLayout
   /* eslint-disable @typescript-eslint/no-explicit-any */
   component: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -46,9 +48,17 @@ export interface IAppRoute {
   path: string;
   title: string;
   isAsync?: boolean;
+  routes?: undefined;
 }
 
-const routes: IAppRoute[] = [
+export interface IAppRouteGroup {
+  label: string;
+  routes: IAppRoute[];
+}
+
+export type AppRouteConfig = IAppRoute | IAppRouteGroup;
+
+const routes: AppRouteConfig[] = [
   {
     component: Dashboard,
     exact: true,
@@ -63,6 +73,25 @@ const routes: IAppRoute[] = [
     label: 'Support',
     path: '/support',
     title: 'PatternFly Seed | Support Page',
+  },
+  {
+    label: 'Settings',
+    routes: [
+      {
+        component: GeneralSettings,
+        exact: true,
+        label: 'General',
+        path: '/settings/general',
+        title: 'PatternFly Seed | General Settings',
+      },
+      {
+        component: ProfileSettings,
+        exact: true,
+        label: 'Profile',
+        path: '/settings/profile',
+        title: 'PatternFly Seed | Profile Settings',
+      },
+    ],
   },
 ];
 
@@ -97,10 +126,15 @@ const PageNotFound = ({ title }: { title: string }) => {
   return <Route component={NotFound} />;
 };
 
+const flattenedRoutes: IAppRoute[] = routes.reduce(
+  (flattened, route) => [...flattened, ...(route.routes ? route.routes : [route])],
+  [] as IAppRoute[]
+);
+
 const AppRoutes = (): React.ReactElement => (
   <LastLocationProvider>
     <Switch>
-      {routes.map(({ path, exact, component, title, isAsync }, idx) => (
+      {flattenedRoutes.map(({ path, exact, component, title, isAsync }, idx) => (
         <RouteWithTitleUpdates
           path={path}
           exact={exact}


### PR DESCRIPTION
Currently the seed app has a nice abstraction around route configuration, which allows us to define routes in one place and automatically generates both the react-router tree and the vertical nav tree, and which calls custom hooks for accessibility and page title updates. However, the current implementation only supports a flat list of top-level routes, and if consumers want to use `<NavExpandable>` they will need to refactor or replace this nice route config abstraction.

This PR enhances the `IAppRoute` type defined in `routes.tsx` so that a group of related routes can be expressed as an object in the `routes` array with its own sub-`routes` array. This structure is then flattened so that all the actual routes are still rendered as top-level `<Route>` components. In `AppLayout.tsx` however, these groups are detected and rendered differently, so that the grouped `<NavItem>`s are wrapped in a `<NavExpandable>`. So, we can keep our nice clean abstraction, and now it supports expandable nav!

I've added a Settings group as an example, with Settings -> General and Settings -> Profile page stubs.

<img width="679" alt="Screenshot 2020-07-22 18 06 34" src="https://user-images.githubusercontent.com/811963/88233723-1593b480-cc46-11ea-9dfe-0ca35ae184c2.png">

cc @seanforyou23 