### PR TITLE
Specify the branch for the clone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Patternfly Seed is an open source build scaffolding utility for web apps. The pr
 ## Quick-start
 ```bash
 npm install yarn -g # ensure you have yarn on your machine globally
-git clone https://github.com/patternfly/patternfly-react-seed # clone the project
+git clone --branch javascript https://github.com/patternfly/patternfly-react-seed # clone the project
 cd patternfly-react-seed # navigate into the project directory
 yarn # install patternfly-react-seed dependencies
 yarn build # build the project


### PR DESCRIPTION
Since this README file is for the javascript branch only, I think it is better to specify the branch for the clone command so that the user will pull the javascript version of Patternfly Seed instead of a typescript version.