### PR TITLE
Use route exact property in NavLink

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -54,7 +54,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
 
   const renderNavItem = (route: IAppRoute, index: number) => (
     <NavItem key={`${route.label}-${index}`} id={`${route.label}-${index}`}>
-      <NavLink exact to={route.path} activeClassName="pf-m-current">
+      <NavLink exact={route.exact} to={route.path} activeClassName="pf-m-current">
         {route.label}
       </NavLink>
     </NavItem>


### PR DESCRIPTION
The `src/apps/routes.tsx` includes an `exact` property, but this property is not applied to the `NavLink` presently. This simple change makes the `exact` property functional.