### PR TITLE
fix: move @hot-loader/react-dom to dev webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@hot-loader/react-dom": "^17.0.1",
         "@patternfly/react-core": "^4.84.4",
         "@patternfly/react-icons": "^4.7.22",
         "@patternfly/react-styles": "^4.7.22",
@@ -51,7 +50,6 @@
         "raw-loader": "^4.0.2",
         "react-axe": "^3.5.4",
         "react-docgen-typescript-loader": "^3.7.2",
-        "react-hot-loader": "^4.13.0",
         "react-router-dom": "^5.2.0",
         "regenerator-runtime": "^0.13.7",
         "rimraf": "^3.0.2",
@@ -1783,25 +1781,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
-    },
-    "node_modules/@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      }
-    },
-    "node_modules/@hot-loader/react-dom/node_modules/scheduler": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/@icons/material": {
       "version": "0.2.4",
@@ -21667,34 +21646,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "node_modules/react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/react-hot-loader/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/react-hotkeys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
@@ -29492,27 +29443,6 @@
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
           "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
           "dev": true
-        }
-      }
-    },
-    "@hot-loader/react-dom": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-17.0.1.tgz",
-      "integrity": "sha512-QttzEibkIFkl/WV1dsLXg73YIweNo9ySbB0/26068RqFGWyv7pKyictWsaQXqSj1y66/BDn3kglCHgroGrv3vA==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.1"
-      },
-      "dependencies": {
-        "scheduler": {
-          "version": "0.20.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
-          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
         }
       }
     },
@@ -46312,30 +46242,6 @@
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
-        }
-      }
-    },
-    "react-hot-loader": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.13.0.tgz",
-      "integrity": "sha512-JrLlvUPqh6wIkrK2hZDfOyq/Uh/WeVEr8nc7hkn2/3Ul0sx1Kr5y4kOGNacNRoj7RhwLNcQ3Udf1KJXrqc0ZtA==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dr:surge": "node dr-surge.js",
     "build": "webpack --config webpack.prod.js && npm run dr:surge",
     "start": "sirv dist --cors --single --host --port 8080",
-    "start:dev": "webpack serve --hot --color --progress --config webpack.dev.js",
+    "start:dev": "webpack serve --color --progress --config webpack.dev.js",
     "test": "jest --watch",
     "test:coverage": "jest --coverage",
     "eslint": "eslint --ext .tsx,.js ./src/",
@@ -58,7 +58,6 @@
     "raw-loader": "^4.0.2",
     "react-axe": "^3.5.4",
     "react-docgen-typescript-loader": "^3.7.2",
-    "react-hot-loader": "^4.13.0",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.7",
     "rimraf": "^3.0.2",
@@ -78,7 +77,6 @@
     "webpack-merge": "^5.7.3"
   },
   "dependencies": {
-    "@hot-loader/react-dom": "^17.0.1",
     "@patternfly/react-core": "^4.84.4",
     "@patternfly/react-icons": "^4.7.22",
     "@patternfly/react-styles": "^4.7.22",

--- a/src/app/Support/Support.tsx
+++ b/src/app/Support/Support.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { hot } from 'react-hot-loader/root';
 import { CubesIcon } from '@patternfly/react-icons';
 import {
   PageSection,
@@ -40,5 +39,4 @@ let Support: React.FunctionComponent<ISupportProps> = () => (
   </PageSection>
 )
 
-Support = hot(Support); // enable HMR for this async module
 export { Support };

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,4 +1,3 @@
-import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
 import { BrowserRouter as Router } from 'react-router-dom';
@@ -14,4 +13,4 @@ const App: React.FunctionComponent = () => (
   </Router>
 );
 
-export default hot(App);
+export default App;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -8,9 +8,6 @@ const ASSET_PATH = process.env.ASSET_PATH || '/';
 module.exports = env => {
 
   return {
-    entry: {
-      app: ['react-hot-loader/patch', path.resolve(__dirname, 'src', 'index.tsx')]
-    },
     module: {
       rules: [
         {
@@ -130,9 +127,6 @@ module.exports = env => {
       })
     ],
     resolve: {
-      alias: {
-        'react-dom': '@hot-loader/react-dom',
-      },
       extensions: ['.js', '.ts', '.tsx', '.jsx'],
       plugins: [
         new TsconfigPathsPlugin({

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -15,7 +15,6 @@ module.exports = merge(common('development'), {
     compress: true,
     inline: true,
     historyApiFallback: true,
-    hot: true,
     overlay: true,
     open: true
   },


### PR DESCRIPTION
Currently the hot-loader is included in production, which is unintended.
Moving this to dev makes sure that the dependency is not included in the
production build and is not used unnecessarily