### PR TITLE
fix: pass missing props to Router

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -89,7 +89,7 @@ const RouteWithTitleUpdates = ({ component: Component, isAsync = false, title, .
     return <Component {...rest} {...routeProps} />;
   }
 
-  return <Route render={routeWithTitle} />;
+  return <Route render={routeWithTitle} {...rest}/>;
 };
 
 const PageNotFound = ({ title }: { title: string }) => {


### PR DESCRIPTION
fix: pass missing props to Router
I noticed that props was missing in Router which was causing issue not find route params. 
