### PR TITLE
Remove redundant TypeScript job in CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,22 +7,8 @@ on:
       - release*
 
 jobs:
-  typecheck:
-    name: TypeScript
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-      - name: Install dependencies
-        run: npm install --legacy-peer-deps # TODO remove --legacy-peer-deps after https://github.com/patternfly/patternfly-react-seed/issues/134 is fixed
-      - name: Run tsc
-        run: npm run type-check
   lint:
-    name: ESLint
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Consider a review of this PR to also be a review of https://github.com/patternfly/patternfly-react-seed/pull/147, which I merged by accident 🤦. I'll address any feedback on both changes here, and I promise not to merge this one early 😄 

In https://github.com/patternfly/patternfly-react-seed/pull/147 I added 4 parallel CI jobs for typechecking, linting, running tests and running a build. I opened https://github.com/patternfly/patternfly-react-seed/pull/148 to see it in action, and realized that any failure of the TypeScript job would also cause both the test and the build jobs to fail. Moreover, the test job shows the full tsc output even though the tsc job doesn't (something about running it via jest?).

![Screen Shot 2022-08-18 at 4 22 14 PM](https://user-images.githubusercontent.com/811963/185489380-3df569e3-4526-4d1a-8625-ee7eef867777.png)

At any rate, the standalone typechecking job is unnecessary. This PR removes it and leaves "CI / Lint", "CI / Test" and "CI / Build". I still think it's helpful to have the jobs separated so you can see feedback as soon as possible, easily see which check is failing when viewing the PR, and see all results if multiple things fail (e.g. you have a lint error but you also have an unrelated test failure, and your app still builds).