### PR TITLE
chore(deps): update patternfly deps to v6 alphas

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "webpack-merge": "^5.9.0"
   },
   "dependencies": {
-    "@patternfly/react-core": "6.0.0-alpha.7",
-    "@patternfly/react-icons": "6.0.0-alpha.5",
-    "@patternfly/react-styles": "6.0.0-alpha.5",
+    "@patternfly/react-core": "6.0.0-alpha.19",
+    "@patternfly/react-icons": "6.0.0-alpha.9",
+    "@patternfly/react-styles": "6.0.0-alpha.9",
     "@storybook/builder-webpack5": "^7.5.3",
     "react": "^18",
     "react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,9 @@
     "webpack-merge": "^5.9.0"
   },
   "dependencies": {
-    "@patternfly/react-core": "6.0.0-alpha.19",
-    "@patternfly/react-icons": "6.0.0-alpha.9",
-    "@patternfly/react-styles": "6.0.0-alpha.9",
+    "@patternfly/react-core": "6.0.0-alpha.28",
+    "@patternfly/react-icons": "6.0.0-alpha.11",
+    "@patternfly/react-styles": "6.0.0-alpha.11",
     "@storybook/builder-webpack5": "^7.5.3",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -88,7 +88,7 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   );
 
   const Navigation = (
-    <Nav id="nav-primary-simple" theme="light">
+    <Nav id="nav-primary-simple">
       <NavList id="nav-list-simple">
         {routes.map(
           (route, idx) => route.label && (!route.routes ? renderNavItem(route, idx) : renderNavGroup(route, idx))

--- a/src/app/NotFound/NotFound.tsx
+++ b/src/app/NotFound/NotFound.tsx
@@ -5,8 +5,6 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateFooter,
-  EmptyStateHeader,
-  EmptyStateIcon,
   PageSection,
 } from '@patternfly/react-core';
 import { useHistory } from 'react-router-dom';
@@ -24,14 +22,13 @@ const NotFound: React.FunctionComponent = () => {
 
   return (
     <PageSection>
-    <EmptyState variant="full">
-      <EmptyStateHeader titleText="404 Page not found" icon={<EmptyStateIcon icon={ExclamationTriangleIcon} />} headingLevel="h1" />
-      <EmptyStateBody>
-        We didn&apos;t find a page that matches the address you navigated to.
-      </EmptyStateBody><EmptyStateFooter>
-      <GoHomeBtn />
-    </EmptyStateFooter></EmptyState>
-  </PageSection>
+      <EmptyState titleText="404 Page not found" variant="full" icon={ExclamationTriangleIcon} >
+        <EmptyStateBody>
+          We didn&apos;t find a page that matches the address you navigated to.
+        </EmptyStateBody><EmptyStateFooter>
+        <GoHomeBtn />
+      </EmptyStateFooter></EmptyState>
+    </PageSection>
   )
 };
 

--- a/src/app/Support/Support.tsx
+++ b/src/app/Support/Support.tsx
@@ -6,8 +6,6 @@ import {
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
-  EmptyStateHeader,
-  EmptyStateIcon,
   EmptyStateVariant,
   PageSection,
   Text,
@@ -22,8 +20,7 @@ export interface ISupportProps {
 // eslint-disable-next-line prefer-const
 let Support: React.FunctionComponent<ISupportProps> = () => (
   <PageSection>
-    <EmptyState variant={EmptyStateVariant.full}>
-      <EmptyStateHeader titleText="Empty State (Stub Support Module)" icon={<EmptyStateIcon icon={CubesIcon} />} headingLevel="h1" />
+    <EmptyState variant={EmptyStateVariant.full} titleText="Empty State (Stub Support Module)" icon={CubesIcon} >
       <EmptyStateBody>
         <TextContent>
           <Text component="p">

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`App tests should render default App component 1`] = `
       >
         <nav
           aria-label="Global"
-          class="pf-v5-c-nav pf-m-light"
+          class="pf-v5-c-nav"
           data-ouia-component-id="OUIA-Generated-Nav-1"
           data-ouia-component-type="PF5/Nav"
           data-ouia-safe="true"
@@ -194,7 +194,7 @@ exports[`App tests should render default App component 1`] = `
               </a>
             </li>
             <li
-              class="pf-v5-c-nav__item pf-m-expandable"
+              class="pf-v5-c-nav__item"
               data-ouia-component-id="OUIA-Generated-NavExpandable-1"
               data-ouia-component-type="PF5/NavExpandable"
               data-ouia-safe="true"


### PR DESCRIPTION
Bumps to latest alphas & updates EmptyState components per new API:
```
"@patternfly/react-core": "6.0.0-alpha.28",
"@patternfly/react-icons": "6.0.0-alpha.11",
"@patternfly/react-styles": "6.0.0-alpha.11"
```

Replacement of prior open PR https://github.com/patternfly/patternfly-react-seed/pull/197