### PR TITLE
chore(docs): bump to latest alpha versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "6.0.0-alpha.68",
-        "@patternfly/react-icons": "6.0.0-alpha.24",
-        "@patternfly/react-styles": "6.0.0-alpha.24",
+        "@patternfly/react-core": "6.0.0-alpha.83",
+        "@patternfly/react-icons": "6.0.0-alpha.30",
+        "@patternfly/react-styles": "6.0.0-alpha.29",
         "react": "^18",
         "react-dom": "^18",
         "sirv-cli": "^2.0.2"
@@ -1723,13 +1723,13 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.0.0-alpha.68",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0-alpha.68.tgz",
-      "integrity": "sha512-YhZY4xuDF0WJyDAAzHdvhgYCECs5bY4+QYUbkPe+dGLNLnwVMU3ZwZlLD9ARHRwfXDRV3g+ttS8HRbigbHgtpQ==",
+      "version": "6.0.0-alpha.83",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0-alpha.83.tgz",
+      "integrity": "sha512-rGMHa2OGAS2ileu1KO4Lq970XQF8Pyw6iIUwvIcFsdktdbM3nIqW/SgNKZ3d6VOP+fV0R4iZ5b6Sj0QMvHzOzQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^6.0.0-alpha.24",
-        "@patternfly/react-styles": "^6.0.0-alpha.24",
-        "@patternfly/react-tokens": "^6.0.0-alpha.24",
+        "@patternfly/react-icons": "^6.0.0-alpha.30",
+        "@patternfly/react-styles": "^6.0.0-alpha.29",
+        "@patternfly/react-tokens": "^6.0.0-alpha.29",
         "focus-trap": "7.5.4",
         "react-dropzone": "^14.2.3",
         "tslib": "^2.6.2"
@@ -1740,23 +1740,23 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.24.tgz",
-      "integrity": "sha512-SRW9sTaHTbMJu+lf7+vWe5fNI1hfquZB6xlJe54D4WAzgzPDTxwPRi6I/KEboKBMZOvU/FYxH2/L5TCYmH51Hw==",
+      "version": "6.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0-alpha.30.tgz",
+      "integrity": "sha512-w9ct8Rf9a0IURq/GO9jXLEr5528DKpKvy35Ys00NXI/V0j48LAiAwu8AFCvWq9zXnLyk9r/0szGC4Ur4wUDt9g==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0-alpha.24.tgz",
-      "integrity": "sha512-9Gh0CbeShaNOJSRy/Y7dEx+Nc9rlDrgjSF9rMtjlFTLfU7HvVavrfuBTGV5NpFJlVBtudJAsDaNRTlC22kKokg=="
+      "version": "6.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0-alpha.29.tgz",
+      "integrity": "sha512-A/VcVS28kUVPcUtyjA07hciAInyxWD9+5TCJM3pZKGPO3Tsvay3EC4pr1yOJiqk1lHGZVwPcu6bxlhJdaC5wCA=="
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.24.tgz",
-      "integrity": "sha512-jIVaGxxZD8Wsp2Xbf8z9mrpfYQx4NzlWlUza0IoTuwslEdcxt77Yo3sh0qlyfRBDNx+Q01tdEFXftJ+6OZQ3Gw=="
+      "version": "6.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0-alpha.29.tgz",
+      "integrity": "sha512-Jvps/UoG0otjdvAgnuS9SF9a8FW5JgyZvs6tnaWD6sXjq2Jl0aRERV4gsyNEnR2lRaJX7N1S+P2HUpAQE7iFvw=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "webpack-merge": "^5.10.0"
   },
   "dependencies": {
-    "@patternfly/react-core": "6.0.0-alpha.68",
-    "@patternfly/react-icons": "6.0.0-alpha.24",
-    "@patternfly/react-styles": "6.0.0-alpha.24",
+    "@patternfly/react-core": "6.0.0-alpha.83",
+    "@patternfly/react-icons": "6.0.0-alpha.30",
+    "@patternfly/react-styles": "6.0.0-alpha.29",
     "react": "^18",
     "react-dom": "^18",
     "sirv-cli": "^2.0.2"

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -16,7 +16,11 @@ exports[`App tests should render default App component 1`] = `
         data-ouia-safe="true"
         href="#primary-app-container"
       >
-        Skip to Content
+        <span
+          class="pf-v6-c-button__text"
+        >
+          Skip to Content
+        </span>
       </a>
     </div>
     <header
@@ -34,19 +38,23 @@ exports[`App tests should render default App component 1`] = `
           data-ouia-safe="true"
           type="button"
         >
-          <svg
-            aria-hidden="true"
-            class="pf-v6-svg"
-            fill="currentColor"
-            height="1em"
-            role="img"
-            viewBox="0 0 448 512"
-            width="1em"
+          <span
+            class="pf-v6-c-button__text"
           >
-            <path
-              d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
-            />
-          </svg>
+            <svg
+              aria-hidden="true"
+              class="pf-v6-svg"
+              fill="currentColor"
+              height="1em"
+              role="img"
+              viewBox="0 0 448 512"
+              width="1em"
+            >
+              <path
+                d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"
+              />
+            </svg>
+          </span>
         </button>
       </span>
       <div
@@ -280,14 +288,18 @@ exports[`App tests should render default App component 1`] = `
         <section
           class="pf-v6-c-page__main-section"
         >
-          <h1
-            class="pf-v6-c-title pf-m-lg"
-            data-ouia-component-id="OUIA-Generated-Title-1"
-            data-ouia-component-type="PF6/Title"
-            data-ouia-safe="true"
+          <div
+            class="pf-v6-c-page__main-body"
           >
-            Dashboard Page Title!
-          </h1>
+            <h1
+              class="pf-v6-c-title pf-m-lg"
+              data-ouia-component-id="OUIA-Generated-Title-1"
+              data-ouia-component-type="PF6/Title"
+              data-ouia-safe="true"
+            >
+              Dashboard Page Title!
+            </h1>
+          </div>
         </section>
       </main>
     </div>


### PR DESCRIPTION
Bumps versions:

```
 "@patternfly/react-core": "6.0.0-alpha.83",
 "@patternfly/react-icons": "6.0.0-alpha.30",
 "@patternfly/react-styles": "6.0.0-alpha.29",
```

to get v6 up to latest PF alphas. 